### PR TITLE
Allow newer node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jasmine-node": "^1.14.5"
   },
   "engines": {
-    "node": "^0.8.0"
+    "node": ">=0.8.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
The latest stable version is 0.10.x.
