### PR TITLE
New Collections

### DIFF
--- a/spec/value-generators.spec.js
+++ b/spec/value-generators.spec.js
@@ -187,7 +187,7 @@ describe('value generator', () => {
   })
 
   it('generates arrays of a certain length', () => {
-    const vals = sample(gen.array(gen.null, 3), 100)
+    const vals = sample(gen.array(gen.null, { size: 3 }), 100)
     expect(vals.length).toBe(100)
     expect(vals).toAllPass(function (value) {
       return Array.isArray(value) &&
@@ -196,7 +196,7 @@ describe('value generator', () => {
   })
 
   it('generates arrays within a length range', () => {
-    const vals = sample(gen.array(gen.null, 3, 5), 100)
+    const vals = sample(gen.array(gen.null, { minSize: 3, maxSize: 5 }), 100)
     expect(vals.length).toBe(100)
     expect(vals).toAllPass(function (value) {
       return Array.isArray(value) &&
@@ -227,13 +227,53 @@ describe('value generator', () => {
     })
   })
 
-  it('generates objects with alphanum keys', () => {
+  it('generates objects of a specific size', () => {
+    const vals = sample(gen.object(gen.null, { size: 10 }), 50)
+    expect(vals.length).toBe(50)
+    expect(vals).toAllPass(function (value) {
+      const keys = Object.keys(value)
+      return value.constructor === Object &&
+        keys.length === 10 &&
+        keys.every(function (key) {
+          return typeof key === 'string' && value[key] === null
+        })
+    })
+  })
+
+  it('generates objects in a specific size range', () => {
+    const vals = sample(gen.object(gen.null, { minSize: 3, maxSize: 6 }), 50)
+    expect(vals.length).toBe(50)
+    expect(vals).toAllPass(function (value) {
+      const keys = Object.keys(value)
+      return value.constructor === Object &&
+        keys.length >= 3 &&
+        keys.length <= 6 &&
+        keys.every(function (key) {
+          return typeof key === 'string' && value[key] === null
+        })
+    })
+  })
+
+  it('generates objects with specific keys', () => {
     const vals = sample(gen.object(gen.alphaNumString, gen.null), 50)
     expect(vals.length).toBe(50)
     expect(vals).toAllPass(function (value) {
       const keys = Object.keys(value)
       return value.constructor === Object &&
         keys.length >= 0 &&
+        keys.every(function (key) {
+          return typeof key === 'string' && ALPHA_NUM_RX.test(key) && value[key] === null
+        })
+    })
+  })
+
+  it('generates objects with specific keys of a specific size', () => {
+    const vals = sample(gen.object(gen.alphaNumString, gen.null, { size: 10 }), 50)
+    expect(vals.length).toBe(50)
+    expect(vals).toAllPass(function (value) {
+      const keys = Object.keys(value)
+      return value.constructor === Object &&
+        keys.length === 10 &&
         keys.every(function (key) {
           return typeof key === 'string' && ALPHA_NUM_RX.test(key) && value[key] === null
         })

--- a/type-definitions/testcheck.d.ts
+++ b/type-definitions/testcheck.d.ts
@@ -53,6 +53,26 @@ export interface Result {
 }
 
 /**
+ * Options to be passed to array() or object()
+ */
+interface SizeOptions {
+  /**
+   * If provided, the exact size of the resulting collection.
+   */
+  size?: number,
+
+  /**
+   * If provided, the minimum size of the resulting collection.
+   */
+  minSize?: number,
+
+  /**
+   * If provided, the maximum size of the resulting collection.
+   */
+  maxSize?: number,
+}
+
+/**
  * Generators of values.
  */
 export class Generator<T> {
@@ -278,8 +298,7 @@ export const gen: {
    */
   array: {
     <T>(valueGen: Generator<T>): Generator<Array<T>>;
-    <T>(valueGen: Generator<T>, length: number): Generator<Array<T>>;
-    <T>(valueGen: Generator<T>, min: number, max: number): Generator<Array<T>>;
+    <T>(valueGen: Generator<T>, options?: SizeOptions): Generator<Array<T>>;
     <T1, T2, T3, T4, T5>(tupleGens: [T1 | Generator<T1>, T2 | Generator<T2>, T3 | Generator<T3>, T4 | Generator<T4>, T5 | Generator<T5>]): Generator<[T1, T2, T3, T4, T5]>;
     <T1, T2, T3, T4>(tupleGens: [T1 | Generator<T1>, T2 | Generator<T2>, T3 | Generator<T3>, T4 | Generator<T4>]): Generator<[T1, T2, T3, T4]>;
     <T1, T2, T3>(tupleGens: [T1 | Generator<T1>, T2 | Generator<T2>, T3 | Generator<T3>]): Generator<[T1, T2, T3]>;
@@ -306,8 +325,8 @@ export const gen: {
    *
    */
   object: {
-    <T>(valueGen: Generator<T>): Generator<{[key: string]: T}>;
-    <T>(keyGen: Generator<string>, valueGen: Generator<T>): Generator<{[key: string]: T}>;
+    <T>(valueGen: Generator<T>, options?: SizeOptions): Generator<{[key: string]: T}>;
+    <T>(keyGen: Generator<string>, valueGen: Generator<T>, options?: SizeOptions): Generator<{[key: string]: T}>;
     (genMap: {[key: string]: Generator<any>}): Generator<{[key: string]: any}>;
   };
 

--- a/type-definitions/testcheck.js.flow
+++ b/type-definitions/testcheck.js.flow
@@ -53,6 +53,26 @@ export type Result = {|
 |};
 
 /**
+ * Options to be passed to array() or object()
+ */
+type SizeOptions = {|
+  /**
+   * If provided, the exact size of the resulting collection.
+   */
+  size?: number,
+
+  /**
+   * If provided, the minimum size of the resulting collection.
+   */
+  minSize?: number,
+
+  /**
+   * If provided, the maximum size of the resulting collection.
+   */
+  maxSize?: number,
+|};
+
+/**
  * Generators of values.
  */
 declare export class Generator<+T> {
@@ -310,7 +330,7 @@ declare export var gen: {
    */
   array: {
     <Elem, T:Array<Generator<Elem> | Elem>>(tupleGens: T): Generator<$TupleMap<T,<V>(Generator<V>) => V>>;
-    <T>(valueGen: Generator<T>, lengthOrMin?: number, max?:number): Generator<Array<T>>;
+    <T>(valueGen: Generator<T>, options?: SizeOptions): Generator<Array<T>>;
   };
 
   /**
@@ -333,8 +353,8 @@ declare export var gen: {
    */
   object: {
     <Elem, T:{[key: string]: Generator<Elem> | Elem}>(recordGens: T): Generator<$ObjMap<T,<V>(Generator<V>) => V>>;
-    <V>(valueGen: Generator<V>, _: void): Generator<{[key: string]: V}>;
-    <K,V>(keyGen: Generator<K>, valueGen: Generator<V>): Generator<{[key: K]: V}>;
+    <V>(valueGen: Generator<V>, options?: SizeOptions): Generator<{[key: string]: V}>;
+    <K,V>(keyGen: Generator<K>, valueGen: Generator<V>, options?: SizeOptions): Generator<{[key: K]: V}>;
   };
 
   /**


### PR DESCRIPTION
This consolidates collection generation code into the gen.array and gen.object methods.

In addition, this adds consistent size options between the two.

Note: existing behavior exists with deprecation warnings