### PR TITLE
#47 Upgrade ava and Patch ava-check 'async' error on non-async tests

### DIFF
--- a/integrations/ava-check/ava-check.js
+++ b/integrations/ava-check/ava-check.js
@@ -44,9 +44,6 @@ function check(/* [options,] ...args, propertyFn */) {
         throw new TypeError('ava-check cannot check async tests.');
       }
 
-      // Check plan after every run.
-      test._checkPlanCount();
-
       if (test.assertError) {
         throw test.assertError;
       }
@@ -58,8 +55,8 @@ function check(/* [options,] ...args, propertyFn */) {
     var checkResult = testcheck.check(property, options);
 
     // Check for async assertions
-    if (!this.sync) {
-      throw new TypeError('ava-check cannot check tests with async assertions.');
+    if (this.planCount) {
+      throw new TypeError(`ava-check cannot check tests with async assertions. Please remove \`t.plan(${this.planCount})\`.`);
     }
 
     // Report results

--- a/integrations/ava-check/package.json
+++ b/integrations/ava-check/package.json
@@ -21,7 +21,7 @@
     "testcheck": "^1.0.0-rc"
   },
   "devDependencies": {
-    "ava": "^0.17.0",
+    "ava": "^0.20.0",
     "flow-bin": "^0.37.4",
     "typescript": "^2.1.4"
   },


### PR DESCRIPTION
# Upgrade ava dev dependency to 0.20 and fix 'async' error on non-async tests

Fix #47: ava-check was throwing 'ava-check cannot check tests with async assertions'
on non-async assertions

## Steps to test

- upgrade ava to 0.20 and run the test suite. Should fail
- try the code on this branch, tests should pass again.

## Things Affected

- ava version in devDependencies
- detection of non-kosher async stuff in ava-check

## Solution Description

The Solution is to check for the test plan count. If it's
truthy, that means the user is potentially doing an
async assertion.

Other types of async assertions (using promises, callbacks,
etc.) are caught here:

https://github.com/mheiber/testcheck-js/blob/d77977303baf1a4e31504dd3f3732b13b1628cbe/integrations/ava-check/ava-check.js#L28

and here:

https://github.com/mheiber/testcheck-js/blob/d77977303baf1a4e31504dd3f3732b13b1628cbe/integrations/ava-check/ava-check.js#L44 

so the check I modified for ensuring that the test plan is empty should
cover all the cases.