### PR TITLE
Add TypeScript defs for jasmine-check

### DIFF
--- a/integrations/jasmine-check/package.json
+++ b/integrations/jasmine-check/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/leebyron/testcheck-js/issues"
   },
   "main": "jasmine-check.js",
+  "types": "type-definitions/jasmine-check.d.ts",
   "dependencies": {
     "testcheck": "^1.0.0-rc"
   },

--- a/integrations/jasmine-check/type-definitions/jasmine-check.d.ts
+++ b/integrations/jasmine-check/type-definitions/jasmine-check.d.ts
@@ -1,12 +1,21 @@
-import { Generator } from 'testcheck';
+import { Generator, CheckOptions } from 'testcheck';
 
 declare global {
   type Check<Key extends string> = {
     [checker in Key]: {
-      (description: string): void;
+      (description: string, opts?: CheckOptions): void;
       (description: string, fn: () => void): void;
+      (description: string, opts: CheckOptions, fn: () => void): void;
       <A>(description: string, genA: Generator<A>, fn: (a: A) => void): void;
+      <A>(description: string, opts: CheckOptions, genA: Generator<A>, fn: (a: A) => void): void;
       <A, B>(description: string, genA: Generator<A>, genB: Generator<B>, fn: (a: A, b: B) => void): void;
+      <A, B>(
+        description: string,
+        opts: CheckOptions,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        fn: (a: A, b: B) => void,
+      ): void;
       <A, B, C>(
         description: string,
         genA: Generator<A>,
@@ -14,8 +23,25 @@ declare global {
         genC: Generator<C>,
         fn: (a: A, b: B, c: C) => void,
       ): void;
+      <A, B, C>(
+        description: string,
+        opts: CheckOptions,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        fn: (a: A, b: B, c: C) => void,
+      ): void;
       <A, B, C, D>(
         description: string,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        genD: Generator<D>,
+        fn: (a: A, b: B, c: C, d: D) => void,
+      ): void;
+      <A, B, C, D>(
+        description: string,
+        opts: CheckOptions,
         genA: Generator<A>,
         genB: Generator<B>,
         genC: Generator<C>,
@@ -31,8 +57,29 @@ declare global {
         genE: Generator<E>,
         fn: (a: A, b: B, c: C, d: D, e: E) => void,
       ): void;
+      <A, B, C, D, E>(
+        description: string,
+        opts: CheckOptions,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        genD: Generator<D>,
+        genE: Generator<E>,
+        fn: (a: A, b: B, c: C, d: D, e: E) => void,
+      ): void;
       <A, B, C, D, E, F>(
         description: string,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        genD: Generator<D>,
+        genE: Generator<E>,
+        genF: Generator<F>,
+        fn: (a: A, b: B, c: C, d: D, e: E, f: F) => void,
+      ): void;
+      <A, B, C, D, E, F>(
+        description: string,
+        opts: CheckOptions,
         genA: Generator<A>,
         genB: Generator<B>,
         genC: Generator<C>,
@@ -52,8 +99,33 @@ declare global {
         genG: Generator<G>,
         fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => void,
       ): void;
+      <A, B, C, D, E, F, G>(
+        description: string,
+        opts: CheckOptions,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        genD: Generator<D>,
+        genE: Generator<E>,
+        genF: Generator<F>,
+        genG: Generator<G>,
+        fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => void,
+      ): void;
       <A, B, C, D, E, F, G, H>(
         description: string,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        genD: Generator<D>,
+        genE: Generator<E>,
+        genF: Generator<F>,
+        genG: Generator<G>,
+        genH: Generator<H>,
+        fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => void,
+      ): void;
+      <A, B, C, D, E, F, G, H>(
+        description: string,
+        opts: CheckOptions,
         genA: Generator<A>,
         genB: Generator<B>,
         genC: Generator<C>,

--- a/integrations/jasmine-check/type-definitions/jasmine-check.d.ts
+++ b/integrations/jasmine-check/type-definitions/jasmine-check.d.ts
@@ -1,0 +1,71 @@
+import { Generator } from 'testcheck';
+
+declare global {
+  type Check<Key extends string> = {
+    [checker in Key]: {
+      (description: string): void;
+      (description: string, fn: () => void): void;
+      <A>(description: string, genA: Generator<A>, fn: (a: A) => void): void;
+      <A, B>(description: string, genA: Generator<A>, genB: Generator<B>, fn: (a: A, b: B) => void): void;
+      <A, B, C>(
+        description: string,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        fn: (a: A, b: B, c: C) => void,
+      ): void;
+      <A, B, C, D>(
+        description: string,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        genD: Generator<D>,
+        fn: (a: A, b: B, c: C, d: D) => void,
+      ): void;
+      <A, B, C, D, E>(
+        description: string,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        genD: Generator<D>,
+        genE: Generator<E>,
+        fn: (a: A, b: B, c: C, d: D, e: E) => void,
+      ): void;
+      <A, B, C, D, E, F>(
+        description: string,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        genD: Generator<D>,
+        genE: Generator<E>,
+        genF: Generator<F>,
+        fn: (a: A, b: B, c: C, d: D, e: E, f: F) => void,
+      ): void;
+      <A, B, C, D, E, F, G>(
+        description: string,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        genD: Generator<D>,
+        genE: Generator<E>,
+        genF: Generator<F>,
+        genG: Generator<G>,
+        fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => void,
+      ): void;
+      <A, B, C, D, E, F, G, H>(
+        description: string,
+        genA: Generator<A>,
+        genB: Generator<B>,
+        genC: Generator<C>,
+        genD: Generator<D>,
+        genE: Generator<E>,
+        genF: Generator<F>,
+        genG: Generator<G>,
+        genH: Generator<H>,
+        fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => void,
+      ): void;
+    }
+  };
+
+  export var check: Check<'it' | 'xit' | 'iit' | 'fit'> & { it: Check<'only' | 'skip'> };
+}


### PR DESCRIPTION
Adds type definitions for global operators `check.it`, `check.it.only`, etc.

(I guess this PR shows how much TS sucks for variadic functions).