### PR TITLE
Improve gen.object

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "flow-bin": "^0.37.3",
     "jasmine-node": "^1.14.5",
-    "typescript": "^2.1.4"
+    "typescript": "^2.4.2"
   },
   "files": [
     "dist",

--- a/test/types.ts
+++ b/test/types.ts
@@ -109,3 +109,42 @@ check(
   // $ExpectError catches mistyped options
   { numTimes: 1000 }
 )
+
+type Person = {
+  name: string,
+  age: number
+}
+
+// Test: Everything OK
+const personGen = gen.object<Person>({
+  name: gen.string,
+  age: gen.number
+});
+
+// $ExpectError missing 'age' key in generator
+gen.object<Person>({
+  name: gen.string
+});
+
+// $ExpectError 'likesDancing' is not part of a person
+gen.object<Person>({
+  name: gen.string,
+  age: gen.number,
+  likesDancing: gen.boolean
+});
+
+type Parent = {
+  child: Person
+};
+
+// Test: Works with composite generators
+gen.object<Parent>({
+  child: personGen
+});
+
+// $ExpectError child generator is not a Person
+gen.object<Parent>({
+  child: gen.object({
+    name: gen.string
+  })
+});

--- a/test/types.ts.expected
+++ b/test/types.ts.expected
@@ -4,3 +4,12 @@ test/types.ts(40,12): error TS2362: The left-hand side of an arithmetic operatio
 test/types.ts(58,15): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 test/types.ts(110,5): error TS2345: Argument of type '{ numTimes: number; }' is not assignable to parameter of type 'CheckOptions | undefined'.
   Object literal may only specify known properties, and 'numTimes' does not exist in type 'CheckOptions | undefined'.
+test/types.ts(125,20): error TS2345: Argument of type '{ name: Generator<string>; }' is not assignable to parameter of type '{ name: Generator<string>; age: Generator<number>; }'.
+  Property 'age' is missing in type '{ name: Generator<string>; }'.
+test/types.ts(133,3): error TS2345: Argument of type '{ name: Generator<string>; age: Generator<number>; likesDancing: Generator<boolean>; }' is not assignable to parameter of type '{ name: Generator<string>; age: Generator<number>; }'.
+  Object literal may only specify known properties, and 'likesDancing' does not exist in type '{ name: Generator<string>; age: Generator<number>; }'.
+test/types.ts(146,20): error TS2345: Argument of type '{ child: Generator<{}>; }' is not assignable to parameter of type '{ child: Generator<Person>; }'.
+  Types of property 'child' are incompatible.
+    Type 'Generator<{}>' is not assignable to type 'Generator<Person>'.
+      Type '{}' is not assignable to type 'Person'.
+        Property 'name' is missing in type '{}'.

--- a/type-definitions/testcheck.d.ts
+++ b/type-definitions/testcheck.d.ts
@@ -431,7 +431,7 @@ export const gen: {
   object: {
     <T>(valueGen: Generator<T>, options?: SizeOptions): Generator<{[key: string]: T}>;
     <T>(keyGen: Generator<string>, valueGen: Generator<T>, options?: SizeOptions): Generator<{[key: string]: T}>;
-    (genMap: {[key: string]: Generator<any>}): Generator<{[key: string]: any}>;
+    <T, V = { [K in keyof T]: Generator<T[K]> }, W = Generator<T>>(genMap: V): W;
   };
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,9 +94,9 @@ sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
-typescript@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.4.tgz#b53b69fb841126acb1dd4b397d21daba87572251"
+typescript@^2.4.2:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.1.tgz#ce7cc93ada3de19475cc9d17e3adea7aee1832aa"
 
 "underscore@>= 1.3.1":
   version "1.8.3"


### PR DESCRIPTION
This change is necessary in order to make testcheck usable for me for non-trivial projects.

`gen.object` is arguably the most important generator because of how it maps directly to type aliases but telling TS that it returns `Generator<any>` makes it super prone to errors. i.e. after a type change, my tests can still continue to pass even though the type checker fails. Here we force generators to stay in sync with type definitions.