### PR TITLE
fix(package.json): prepublish -> prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ts-check-update": "tsc --noEmit --noImplicitAny --strictNullChecks test/types.ts > test/types.ts.expected; exit 0",
     "build": "rm -f dist/* && lein do clean, cljsbuild once && cp type-definitions/* dist/",
     "rebuild": "lein do cljsbuild once && cp type-definitions/* dist/",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
npm 4+ is splitting the prepublish script into two new: prepare and prepublishOnly.

**prepare** will have the same behavior that prepublish has now. Commands in this script will run both before publishing and on npm install.  

**prepublishOnly**, as seen from its name, will run only before publishing the package.

Also, prepublish will receive a warning about the changes.