### PR TITLE
Initial exploration into an async check

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,10 @@
   :source-paths ["src"]
 
   :dependencies [
-    [org.clojure/clojure "1.8.0"]
+    [org.clojure/clojure "1.9.0-alpha14"]
     [org.clojure/clojurescript "1.9.293"]
-    [org.clojure/test.check "0.9.0"]]
+    [org.clojure/test.check "0.9.0"]
+    [io.nervous/promesa-check "0.1.1"]]
 
   :plugins [
     [lein-cljsbuild "1.1.5"]]

--- a/test/check.spec.js
+++ b/test/check.spec.js
@@ -5,9 +5,15 @@
 /*:: declare function expect(val: any): any; */
 /*:: declare var jasmine: any; */
 
-const { check, property, gen } = require('../')
+const { check, checkAsync, property, gen } = require('../')
 
 describe('check', () => {
+
+  it('async', (done) => {
+    const promise = checkAsync(property(gen.int, (i) => Promise.resolve(i)))
+
+    promise.then((result) => console.log(result) || done())
+  })
 
   it('checks true properties', () => {
 


### PR DESCRIPTION
Following on from #45 

All credit for the async quick-check implementation goes to [promesa-check](http://github.com/nervous-systems/promesa-check) ⭐️ 

This PR adds this behind a new function: `checkAsync`. This acts exactly the same as `check` except that the property function needs to return a promise.

Ideally I'd prefer `check` to be able to accept both sync and async properties, which I may work on, but thought I'd share this for some early feedback