### PR TITLE
Print seed in integration results

### DIFF
--- a/integrations/ava-check/ava-check.js
+++ b/integrations/ava-check/ava-check.js
@@ -65,7 +65,7 @@ function check(/* [options,] ...args, propertyFn */) {
       var args = shrunk ? shrunk.smallest : checkResult.fail;
       var result = shrunk ? shrunk.result : checkResult.result;
 
-      test.title += ' ' + printArgs(args)
+      test.title += ' ' + printArgs(args, checkResult.seed);
       if (result instanceof Error) {
         test.assertError = cleanStack(result);
       } else {
@@ -80,8 +80,10 @@ function check(/* [options,] ...args, propertyFn */) {
   }
 }
 
-function printArgs(args) {
-  return '(' + require('util').inspect(args, { depth: null, colors: true }).slice(1, -1) + ')'
+function printArgs(args, seed) {
+  const inspect = require('util').inspect;
+  return ' (' + inspect(args, { depth: null, colors: true }).slice(1, -1) +
+    ') Seed: ' + inspect(seed, { colors: true });
 }
 
 function cleanStack(error) {

--- a/integrations/jasmine-check/jasmine-check.js
+++ b/integrations/jasmine-check/jasmine-check.js
@@ -115,7 +115,9 @@ function checkIt(it) {
       // Run testcheck
       var checkResult = testcheck.check(property, options);
       if (checkResult.fail) {
-        var failingArgs = printArgs(checkResult.shrunk.smallest, checkResult.seed);
+        var shrunk = checkResult.shrunk;
+        var args = shrunk ? shrunk.smallest : checkResult.fail;
+        var failingArgs = printArgs(args, checkResult.seed);
         spec.description += failingArgs;
         if (spec.results) {
           spec.results().description += failingArgs;
@@ -153,9 +155,9 @@ function logException(e) {
 }
 
 function printArgs(args, seed) {
-  const inspect = require('util').inspect
-  let toStr = (x) => inspect(x, { depth: null, colors: true }).slice(1, -1)
-  return ' (' + toStr(args) + ') Seed:' + toStr([seed]);
+  const inspect = require('util').inspect;
+  return ' (' + inspect(args, { depth: null, colors: true }).slice(1, -1) +
+    ') Seed: ' + inspect(seed, { colors: true });
 }
 
 exports.install = install;

--- a/integrations/mocha-testcheck/mocha-check.js
+++ b/integrations/mocha-testcheck/mocha-check.js
@@ -84,7 +84,9 @@ function CheckFailure(checkResult) {
   var args = shrunk ? shrunk.smallest : checkResult.fail;
   var result = shrunk ? shrunk.result : checkResult.result;
   this.check = checkResult
-  this.message = printArgs(args) + ' => ' + String(result);
+  this.message =
+    printArgs(args) + ' => ' + String(result) +
+    printSeed(checkResult.seed);
 
   if (result instanceof Error) {
     // Edit stack
@@ -103,8 +105,12 @@ CheckFailure.prototype = Object.create(Error.prototype);
 CheckFailure.prototype.name = 'CheckFailure';
 CheckFailure.prototype.constructor = CheckFailure;
 
-function printArgs(args) {
-  return '(' + require('util').inspect(args).slice(1, -1) + ')'
+function printArgs(args, seed) {
+  return '(' + require('util').inspect(args, { depth: null, colors: true }).slice(1, -1) + ')';
+}
+
+function printSeed(seed) {
+  return ' (Seed: ' + require('util').inspect(seed, { colors: true }) + ')';
 }
 
 function stackFrames(error) {

--- a/integrations/mocha-testcheck/test/check.test.js
+++ b/integrations/mocha-testcheck/test/check.test.js
@@ -38,29 +38,51 @@ describe('check', function () {
   })
 
   it('outputs well formed shrunk data', () => {
-    expect(() => {
+    let caughtError;
+    try {
       check.it('will fail with this assertion', gen.int, x => {
         expect(x).to.at.most(10)
       }).fn()
-    }).to.throw('( \u001b[33m11\u001b[39m ) => AssertionError: expected 11 to be at most 10')
+    } catch (error) {
+      caughtError = error;
+    }
+    expect(noColor(caughtError.message)).to.contain(
+      '( 11 ) => AssertionError: expected 11 to be at most 10'
+    );
   })
 
   it('outputs well formed shrunk data when throwing normal error', () => {
-    expect(() => {
+    let caughtError;
+    try {
       check.it('will fail with this assertion', gen.int, x => {
         if (x > 10) {
           throw new Error('Expected ' + x + ' to be at most 10');
         }
       }).fn()
-    }).to.throw('( \u001b[33m11\u001b[39m ) => Error: Expected 11 to be at most 10')
+    } catch (error) {
+      caughtError = error;
+    }
+    expect(noColor(caughtError.message)).to.contain(
+      '( 11 ) => Error: Expected 11 to be at most 10'
+    );
   })
 
   it('outputs well formed shrunk data when returning boolean', () => {
-    expect(() => {
+    let caughtError;
+    try {
       check.it('will fail with this assertion', gen.int, x =>
         x <= 10
       ).fn()
-    }).to.throw('( \u001b[33m11\u001b[39m ) => false')
+    } catch (error) {
+      caughtError = error;
+    }
+    expect(noColor(caughtError.message)).to.contain(
+      '( 11 ) => false'
+    );
   })
 
 });
+
+function noColor(str) {
+  return str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+}

--- a/integrations/mocha-testcheck/test/check.test.js
+++ b/integrations/mocha-testcheck/test/check.test.js
@@ -42,7 +42,7 @@ describe('check', function () {
       check.it('will fail with this assertion', gen.int, x => {
         expect(x).to.at.most(10)
       }).fn()
-    }).to.throw('( 11 ) => AssertionError: expected 11 to be at most 10')
+    }).to.throw('( \u001b[33m11\u001b[39m ) => AssertionError: expected 11 to be at most 10')
   })
 
   it('outputs well formed shrunk data when throwing normal error', () => {
@@ -52,7 +52,7 @@ describe('check', function () {
           throw new Error('Expected ' + x + ' to be at most 10');
         }
       }).fn()
-    }).to.throw('( 11 ) => Error: Expected 11 to be at most 10')
+    }).to.throw('( \u001b[33m11\u001b[39m ) => Error: Expected 11 to be at most 10')
   })
 
   it('outputs well formed shrunk data when returning boolean', () => {
@@ -60,7 +60,7 @@ describe('check', function () {
       check.it('will fail with this assertion', gen.int, x =>
         x <= 10
       ).fn()
-    }).to.throw('( 11 ) => false')
+    }).to.throw('( \u001b[33m11\u001b[39m ) => false')
   })
 
 });

--- a/integrations/tape-check/tape-check.js
+++ b/integrations/tape-check/tape-check.js
@@ -54,7 +54,7 @@ function check(/* [options,] ...args, propertyFn */) {
       var originalEmit = test.emit;
       test.emit = function (name, data) {
         if (name === 'result') {
-          data.name += printArgs(args);
+          data.name += printArgs(args, checkResult.seed);
         }
         originalEmit.call(test, name, data);
       }
@@ -86,6 +86,8 @@ function assertWrap(ok, opts) {
   this._ok = this._ok && ok;
 }
 
-function printArgs(args) {
-  return ' (' + require('util').inspect(args, { depth: null }).slice(1, -1) + ')'
+function printArgs(args, seed) {
+  const inspect = require('util').inspect;
+  return ' (' + inspect(args, { depth: null, colors: true }).slice(1, -1) +
+    ') Seed: ' + inspect(seed, { colors: true });
 }


### PR DESCRIPTION
Following up on #66 - this prints the seed used when encountering failure to other test integrations, and unifies some behavior in printing between them.

Printing the seed during failure is useful when attempting to reproduce a failing test case on a rare case, or just repeating the same test to consistently reproduce a specific condition. Each integration offers a way to use the printed seed as the specific seed used in a test case.

Fixes #43