### PR TITLE
Fixing a broken example for using .then() API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -922,7 +922,7 @@ integers, and then returns both that Array and a sampled value from it:
 ```js
 var genList = gen.array(gen.int).notEmpty();
 var genListAndItem = genList.then(
-  list => [ list, gen.oneOf(list) ]
+  list => [ list, sampleOne(gen.oneOf(list)) ]
 );
 
 sample(genListAndItem, 3)


### PR DESCRIPTION
Issue:

The example in the documentation for then currently outputs an empty object for the item.

Current Example:
var genList = gen.array(gen.int).notEmpty();
var genListAndItem = genList.then(
  list => [ list, gen.oneOf(list) ]
);

sample(genListAndItem, 3)

Current Output:
[ [ [ 1 ], {} ], [ [ 2, -1 ], {} ], [ [ -3, 2, -1 ], {} ] ]


Fixed  Example:
var genList = gen.array(gen.int).notEmpty();
var genListAndItem = genList.then(
  list => [ list, sampleOne(gen.oneOf(list)) ]
);

sample(genListAndItem, 3)

Fixed Output:
// [ [ [ 1 ], 1 ], [ [ 2, -1 ], 2 ], [ [ -3, 2, -1 ], 2 ] ]

