### PR TITLE
Allow optional seed to be passed sampleOne

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -191,12 +191,15 @@ sampleOne([ gen.int, gen.alphaNumChar ])
 **Parameters**
 
 ```
-sample(generator[, size])
+sample(generator[, size [, seed]])
 ```
 
 * `generator`: Any *ValueGenerator* object.
 
 * `size`: The size of the value to produce. Default: `30`.
+
+* `seed`: The seed to use for the random number generator. Default: *<Random>*
+
 
 **Returns**
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [
     [org.clojure/clojure "1.8.0"]
     [org.clojure/clojurescript "1.9.293"]
-    [org.clojure/test.check "0.9.0"]]
+    [org.clojure/test.check "0.10.0-alpha3"]]
 
   :plugins [
     [lein-cljsbuild "1.1.5"]]

--- a/src/testcheck.cljs
+++ b/src/testcheck.cljs
@@ -319,8 +319,12 @@
   (to-array (gen/sample (->gen generator) (or num-samples 10)))))
 
 (defexport sampleOne (fn
-  [generator size]
-  (gen/generate (->gen generator) (or size 30))))
+  ([generator]
+  (gen/generate (->gen generator) 30))
+  ([generator size]
+  (gen/generate (->gen generator) size))
+  ([generator size seed]
+  (gen/generate (->gen generator) (or size 30) seed))))
 
 
 

--- a/test/gen-builders.spec.js
+++ b/test/gen-builders.spec.js
@@ -45,6 +45,12 @@ describe('gen builders', () => {
     expect(val).toBe(55)
   })
 
+  it('samples one with a given seed', () => {
+    const a = sampleOne(gen.int, 1, 1);
+    const b = sampleOne(gen.int, 1, 1);
+    expect(a).toBe(b)
+  })
+
   it('generates an exact value', () => {
     const vals = sample(gen.return('wow'), 100)
     expect(vals.length).toBe(100)

--- a/type-definitions/testcheck.d.ts
+++ b/type-definitions/testcheck.d.ts
@@ -232,7 +232,7 @@ export function sample<T>(gen: ValueGenerator<T>, numValues?: number): Array<T>;
  *
  * By default, values of size 30 are produced.
  */
-export function sampleOne<T>(gen: ValueGenerator<T>, size?: number): T;
+export function sampleOne<T>(gen: ValueGenerator<T>, size?: number, seed?: number): T;
 
 
 

--- a/type-definitions/testcheck.js.flow
+++ b/type-definitions/testcheck.js.flow
@@ -252,7 +252,7 @@ declare export function sample<T>(gen: ValueGenerator<T>, numValues?: number): A
  *
  * By default, values of size 30 are produced.
  */
-declare export function sampleOne<T>(gen: ValueGenerator<T>, size?: number): T;
+declare export function sampleOne<T>(gen: ValueGenerator<T>, size?: number, seed?: number): T;
 
 
 


### PR DESCRIPTION
This PR allows sample one to be used deterministically. This is useful to create generators that can then be used with snapshot testing.

- update org.clojure/test.check to 0.10.0-alpha3;
- Add support for passing seed to sampleOne;

Please let me know if there is anything that I missed to get this in.