### PR TITLE
Publish jasmine-check's types file

### DIFF
--- a/integrations/jasmine-check/package.json
+++ b/integrations/jasmine-check/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "jasmine-check.js",
+    "type-definitions/jasmine-check.d.ts",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
As mentioned in [#80](https://github.com/leebyron/testcheck-js/issues/80#issuecomment-394707766), the types file for `jasmine-check` is not being published. Adding it to the `files` option should fix this.